### PR TITLE
Update request so that it doesn't write debug to stdout

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Sam Day <sam.c.day@gmail.com> (http://samcday.com.au/)",
   "name": "deathbycaptcha",
   "description": "DeathByCaptcha Node.js client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "devDependencies": {},
   "optionalDependencies": {},
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "name": "deathbycaptcha",
   "description": "DeathByCaptcha Node.js client",
   "version": "0.0.2",
-  "dependencies": {
-    "request": "~2.9.202"
-  },
   "devDependencies": {},
   "optionalDependencies": {},
   "engines": {
     "node": "*"
   },
-  "main": "./deathbycaptcha"
+  "main": "./deathbycaptcha",
+  "dependencies": {
+    "request": "~2.21.0"
+  }
 }


### PR DESCRIPTION
Not sure if it was debug code in your build, or in the specific version that you bundled to npm, but using this module kept spewing out the mime boundary string to stdout. Looking through the request.js file I found a console.log statement in there for no good reason.

I've updated the request version to be later and that seems to fix the problem.
